### PR TITLE
Updating workflow to replace the deprecated action

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -147,7 +147,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: azure/k8s-actions/k8s-set-context@master
+      - uses: azure/k8s-set-context@v1
         with:
           kubeconfig: ${{ secrets.KUBE_CONFIG }}
       - name: Release Staging environment


### PR DESCRIPTION
Actions hosted in azure/k8s-actions repo are now moved to new GitHub repositories. Please update your existing workflows with the new actions as these old actions have been ARCHIVED and will not receive any updates. Refer to https://github.com/Azure/actions for updated action repo details.
For example, the action azure/k8s-actions/k8s-set-context@master should be replaced with Azure/k8s-set-context@v1 in your workflows. Thanks!