### PR TITLE
Bump quarkus.version from 1.13.7.Final to 2.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
         <jacoco.version>0.8.7</jacoco.version>
         <surefire-plugin.version>2.22.2</surefire-plugin.version>
-        <quarkus.version>1.13.7.Final</quarkus.version>
+        <quarkus.version>2.0.0.Final</quarkus.version>
         <mapstruct.version>1.4.2.Final</mapstruct.version>
         <lombok.version>1.18.20</lombok.version>        
         <lombok-mapstruct-binding.version>0.2.0</lombok-mapstruct-binding.version>


### PR DESCRIPTION
Bumps `quarkus.version` from 1.13.7.Final to 2.0.0.Final.

Updates `quarkus-bom` from 1.13.7.Final to 2.0.0.Final
- [Release notes](https://github.com/quarkusio/quarkus/releases)
- [Commits](https://github.com/quarkusio/quarkus/compare/1.13.7.Final...2.0.0.Final)

Updates `quarkus-junit5` from 1.13.7.Final to 2.0.0.Final

Updates `quarkus-maven-plugin` from 1.13.7.Final to 2.0.0.Final

---
updated-dependencies:
- dependency-name: io.quarkus:quarkus-bom
  dependency-type: direct:production
  update-type: version-update:semver-major
- dependency-name: io.quarkus:quarkus-junit5
  dependency-type: direct:development
  update-type: version-update:semver-major
- dependency-name: io.quarkus:quarkus-maven-plugin
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>